### PR TITLE
Set ping rate to 30 sec

### DIFF
--- a/lib/grakn/session.ex
+++ b/lib/grakn/session.ex
@@ -3,9 +3,12 @@ defmodule Grakn.Session do
 
   @opaque t :: GRPC.Channel.t()
 
+  # every 30 sec
+  @ping_rate 30_000
+
   @spec new(String.t()) :: {:ok, t()} | {:error, any()}
   def new(uri) do
-    GRPC.Stub.connect(uri)
+    GRPC.Stub.connect(uri, adapter_opts: %{http2_opts: %{keepalive: @ping_rate}})
   end
 
   @spec transaction(t()) :: {:ok, Grakn.Transaction.t()} | {:error, any()}


### PR DESCRIPTION
I was able to reproduce the error of "too many pings" with the performance driver. I found that the default rate used by the gRPC implementations is 5 sec. I bump it to 30. This seems to work with our performance test