### PR TITLE
Add credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ def deps do
 end
 ```
 
+## Configuration
+
+We can specify hostname, pool_size and if needed we can specify the credentials [as per documentation in grakn.ai](http://dev.grakn.ai/docs/management/users#managing-users-kgms-only)
+
+```elixir
+config :grakn_elixir,
+  hostname: "localhost",
+  username: "username",
+  password: "password",
+  pool_size: 4
+```
+
+
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/grakn_elixir](https://hexdocs.pm/grakn_elixir).

--- a/lib/grakn.ex
+++ b/lib/grakn.ex
@@ -109,6 +109,8 @@ defmodule Grakn do
       |> Keyword.put_new(:pool_timeout, get_config(:pool_timeout, :infinity))
       |> Keyword.put_new(:timeout, get_config(:timeout, 30_000))
       |> Keyword.put_new(:queue, get_config(:queue, true))
+      |> Keyword.put_new(:username, get_config(:username, ""))
+      |> Keyword.put_new(:password, get_config(:password, ""))
 
     case get_config(:log) do
       nil -> opts_with_defaults

--- a/lib/grakn/protocol.ex
+++ b/lib/grakn/protocol.ex
@@ -40,7 +40,9 @@ defmodule Grakn.Protocol do
            Grakn.Transaction.open(
              tx,
              opts[:keyspace] || "grakn",
-             opts[:type] || Grakn.Transaction.Type.read()
+             opts[:type] || Grakn.Transaction.Type.read(),
+             opts[:username],
+             opts[:password]
            ) do
       {:ok, nil, %{state | transaction: tx}}
     else

--- a/lib/grakn/transaction.ex
+++ b/lib/grakn/transaction.ex
@@ -41,9 +41,9 @@ defmodule Grakn.Transaction do
     end
   end
 
-  @spec open(t(), String.t(), Type.t()) :: {:ok, t()}
-  def open(tx, keyspace, type) do
-    request = Request.open_transaction(keyspace, type)
+  @spec open(t(), String.t(), Type.t(), Type.t(), Type.t()) :: {:ok, t()}
+  def open(tx, keyspace, type, username, password) do
+    request = Request.open_transaction(keyspace, type, username, password)
 
     req_stream =
       tx

--- a/lib/grakn/transaction.ex
+++ b/lib/grakn/transaction.ex
@@ -41,7 +41,7 @@ defmodule Grakn.Transaction do
     end
   end
 
-  @spec open(t(), String.t(), Type.t(), Type.t(), Type.t()) :: {:ok, t()}
+  @spec open(t(), String.t(), Type.t(), String.t(), String.t()) :: {:ok, t()}
   def open(tx, keyspace, type, username, password) do
     request = Request.open_transaction(keyspace, type, username, password)
 

--- a/lib/grakn/transaction/request.ex
+++ b/lib/grakn/transaction/request.ex
@@ -1,10 +1,15 @@
 defmodule Grakn.Transaction.Request do
   @moduledoc false
 
-  def open_transaction(keyspace, type) do
+  def open_transaction(keyspace, type, username, password) do
     transaction_request(
       :open_req,
-      Session.Transaction.Open.Req.new(keyspace: keyspace, type: type)
+      Session.Transaction.Open.Req.new(
+        keyspace: keyspace,
+        type: type,
+        username: username,
+        password: password
+      )
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GraknElixir.MixProject do
   def project do
     [
       app: :grakn_elixir,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Allow using username and password when creating a new transaction

The struct `Session.Transaction.Open.Req` already had default credentials that used empty strings when not set. This does the same, just defaults to empty strings when they are not set in the config and sets them to every new `Session.Transaction.Open.Req` taking advantage of `Grakn.with_transaction_config/1`