### PR TITLE
Fix repeatable attemps to close broken/closed sessions

### DIFF
--- a/lib/grakn/cache/janitor.ex
+++ b/lib/grakn/cache/janitor.ex
@@ -52,6 +52,7 @@ defmodule Grakn.Cache.Janitor do
       type, error ->
         error_spec = {type, error, __STACKTRACE__}
         Logger.warn("Couldn't close session #{session_id}, error: #{inspect(error_spec)}")
+        Cache.delete(key)
     end
   end
 end


### PR DESCRIPTION
Instead of retry, we try and log to close session only once, in a case
it looks broken/results to error, we remove it from cache. Later we need
to identify cases (for example: database temporary unavailble), when we should
retry to close session later.