### PR TITLE
fix: Update run-protoc.sh

### DIFF
--- a/run-protoc.sh
+++ b/run-protoc.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 rm -rf deps/grakn
-git clone https://github.com/graknlabs/grakn.git deps/grakn
+git clone https://github.com/typedb/typedb deps/grakn
 protoc -I deps/grakn --elixir_out=plugins=grpc:./lib/proto/ deps/grakn/protocol/**/*.proto


### PR DESCRIPTION
The repo path has changed from "https://github.com/graknlabs/grakn.git" to "https://github.com/typedb/typedb", and we changing it so no one can create a similar account and repo and gain access to our GitHub.

Thank you